### PR TITLE
chore: add examples directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+.lagon/
 
 .eslintcache
 .DS_Store

--- a/examples/fetch-api/index.ts
+++ b/examples/fetch-api/index.ts
@@ -1,0 +1,10 @@
+export async function handler(request: Request): Promise<Response> {
+  const response = await fetch('https://randomuser.me/api/');
+  const json = await response.json();
+
+  return new Response(`Hello ${json.results[0].name.first}!`, {
+    headers: {
+      'content-type': 'text/html',
+    },
+  });
+}

--- a/examples/fetch-api/package.json
+++ b/examples/fetch-api/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@lagon/example-fetch-api",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@lagon/types": "workspace:^0.0.1"
+  }
+}

--- a/examples/preact-ssr/index.tsx
+++ b/examples/preact-ssr/index.tsx
@@ -1,0 +1,19 @@
+import render from 'preact-render-to-string';
+import { h } from 'preact';
+/** @jsx h */
+
+const App = () => (
+  <div>
+    <h1>Hello World!</h1>
+  </div>
+);
+
+const html = render(<App />);
+
+export async function handler(request: Request): Promise<Response> {
+  return new Response(html, {
+    headers: {
+      'content-type': 'text/html',
+    },
+  });
+}

--- a/examples/preact-ssr/package.json
+++ b/examples/preact-ssr/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lagon/example-preact-ssr",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@lagon/types": "workspace:^0.0.1",
+    "preact": "^10.8.2",
+    "preact-render-to-string": "^5.2.0"
+  }
+}

--- a/examples/react-ssr/index.tsx
+++ b/examples/react-ssr/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+const App = () => (
+  <div>
+    <h1>Hello World!</h1>
+  </div>
+);
+
+const html = renderToString(<App />);
+
+export async function handler(request: Request): Promise<Response> {
+  return new Response(html, {
+    headers: {
+      'content-type': 'text/html',
+    },
+  });
+}

--- a/examples/react-ssr/package.json
+++ b/examples/react-ssr/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@lagon/example-react-ssr",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@lagon/types": "workspace:^0.0.1",
+    "@types/react": "^18.0.9",
+    "@types/react-dom": "^18.0.5",
+    "react": "18.1.0",
+    "react-dom": "18.1.0"
+  }
+}

--- a/examples/reply-with-html/index.ts
+++ b/examples/reply-with-html/index.ts
@@ -1,0 +1,19 @@
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hello World!</title>
+</head>
+  <body>
+    <h1>Hello World!</h1>
+  </body>
+</html>`;
+
+export function handler(request: Request): Response {
+  return new Response(html, {
+    headers: {
+      'content-type': 'text/html',
+    },
+  });
+}

--- a/examples/reply-with-html/package.json
+++ b/examples/reply-with-html/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@lagon/example-reply-with-html",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@lagon/types": "workspace:^0.0.1"
+  }
+}

--- a/examples/reply-with-json/index.ts
+++ b/examples/reply-with-json/index.ts
@@ -1,0 +1,11 @@
+const json = JSON.stringify({
+  message: 'Hello World!',
+});
+
+export function handler(request: Request): Response {
+  return new Response(json, {
+    headers: {
+      'content-type': 'application/json',
+    },
+  });
+}

--- a/examples/reply-with-json/package.json
+++ b/examples/reply-with-json/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@lagon/example-reply-with-json",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@lagon/types": "workspace:^0.0.1"
+  }
+}

--- a/packages/cli/src/utils/deployments.ts
+++ b/packages/cli/src/utils/deployments.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { transform } from 'esbuild';
+import { build } from 'esbuild';
 import path from 'node:path';
 import { authToken } from '../auth';
 import { trpc } from '../trpc';
@@ -42,10 +42,16 @@ export function removeDeploymentFile(file: string) {
 }
 
 export async function bundleFunction(file: string): Promise<string> {
-  const code = fs.readFileSync(file, 'utf-8');
-
-  const { code: finalCode } = await transform(code, {
-    loader: 'tsx',
+  const { outputFiles } = await build({
+    entryPoints: [file],
+    bundle: true,
+    write: false,
+    loader: {
+      '.ts': 'ts',
+      '.tsx': 'tsx',
+      '.js': 'js',
+      '.jsx': 'jsx',
+    },
     format: 'esm',
     target: 'es2020',
     // TODO: minify identifiers
@@ -55,7 +61,7 @@ export async function bundleFunction(file: string): Promise<string> {
     minifySyntax: true,
   });
 
-  return finalCode;
+  return outputFiles[0].text;
 }
 
 export async function createDeployment(functionId: string, file: string) {

--- a/packages/runtime/src/fetch/index.ts
+++ b/packages/runtime/src/fetch/index.ts
@@ -1,3 +1,4 @@
+import https from 'node:https';
 import http from 'node:http';
 import { Headers } from '../runtime/fetch';
 import { RequestInit } from '../runtime/Request';
@@ -22,7 +23,7 @@ export async function fetch(resource: string, init?: RequestInit): Promise<Fetch
       }
     }
 
-    const request = http.request(
+    const request = (resource.startsWith('https') ? https : http).request(
       resource,
       {
         method: init?.method || 'GET',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,16 @@ importers:
     dependencies:
       '@lagon/types': link:../../packages/types
 
+  examples/preact:
+    specifiers:
+      '@lagon/types': workspace:^0.0.1
+      preact: ^10.8.2
+      preact-render-to-string: ^5.2.0
+    dependencies:
+      '@lagon/types': link:../../packages/types
+      preact: 10.8.2
+      preact-render-to-string: 5.2.0_preact@10.8.2
+
   examples/reply-with-html:
     specifiers:
       '@lagon/types': workspace:^0.0.1
@@ -13348,6 +13358,19 @@ packages:
     dependencies:
       preact: 10.8.2
       pretty-format: 3.8.0
+    dev: false
+
+  /preact-render-to-string/5.2.0_preact@10.8.2:
+    resolution: {integrity: sha512-+RGwSW78Cl+NsZRUbFW1MGB++didsfqRk+IyRVTaqy+3OjtpKK/6HgBtfszUX0YXMfo41k2iaQSseAHGKEwrbg==}
+    peerDependencies:
+      preact: '>=10'
+    dependencies:
+      preact: 10.8.2
+      pretty-format: 3.8.0
+    dev: false
+
+  /preact/10.7.2:
+    resolution: {integrity: sha512-GLjn0I3r6ka+NvxJUppsVFqb4V0qDTEHT/QxHlidPuClGaxF/4AI2Qti4a0cv3XMh5n1+D3hLScW10LRIm5msQ==}
     dev: false
 
   /preact/10.8.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,24 @@ importers:
       vite-tsconfig-paths: 3.5.0
       vitest: 0.15.2
 
+  examples/fetch-api:
+    specifiers:
+      '@lagon/types': workspace:^0.0.1
+    dependencies:
+      '@lagon/types': link:../../packages/types
+
+  examples/reply-with-html:
+    specifiers:
+      '@lagon/types': workspace:^0.0.1
+    dependencies:
+      '@lagon/types': link:../../packages/types
+
+  examples/reply-with-json:
+    specifiers:
+      '@lagon/types': workspace:^0.0.1
+    dependencies:
+      '@lagon/types': link:../../packages/types
+
   packages/cli:
     specifiers:
       '@trpc/client': ^9.25.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
     dependencies:
       '@lagon/types': link:../../packages/types
 
-  examples/preact:
+  examples/preact-ssr:
     specifiers:
       '@lagon/types': workspace:^0.0.1
       preact: ^10.8.2
@@ -13358,19 +13358,6 @@ packages:
     dependencies:
       preact: 10.8.2
       pretty-format: 3.8.0
-    dev: false
-
-  /preact-render-to-string/5.2.0_preact@10.8.2:
-    resolution: {integrity: sha512-+RGwSW78Cl+NsZRUbFW1MGB++didsfqRk+IyRVTaqy+3OjtpKK/6HgBtfszUX0YXMfo41k2iaQSseAHGKEwrbg==}
-    peerDependencies:
-      preact: '>=10'
-    dependencies:
-      preact: 10.8.2
-      pretty-format: 3.8.0
-    dev: false
-
-  /preact/10.7.2:
-    resolution: {integrity: sha512-GLjn0I3r6ka+NvxJUppsVFqb4V0qDTEHT/QxHlidPuClGaxF/4AI2Qti4a0cv3XMh5n1+D3hLScW10LRIm5msQ==}
     dev: false
 
   /preact/10.8.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,20 @@ importers:
       preact: 10.8.2
       preact-render-to-string: 5.2.0_preact@10.8.2
 
+  examples/react-ssr:
+    specifiers:
+      '@lagon/types': workspace:^0.0.1
+      '@types/react': ^18.0.9
+      '@types/react-dom': ^18.0.5
+      react: 18.1.0
+      react-dom: 18.1.0
+    dependencies:
+      '@lagon/types': link:../../packages/types
+      '@types/react': 18.0.14
+      '@types/react-dom': 18.0.5
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+
   examples/reply-with-html:
     specifiers:
       '@lagon/types': workspace:^0.0.1
@@ -5323,7 +5337,6 @@ packages:
     resolution: {integrity: sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==}
     dependencies:
       '@types/react': 18.0.14
-    dev: true
 
   /@types/react-syntax-highlighter/11.0.5:
     resolution: {integrity: sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/*'
+  - 'examples/*'
   - 'www'


### PR DESCRIPTION
Add `examples` directory with examples for:

- how to reply HTML (`reply-with-html`)
- how to reply JSON (`reply-with-json`)
- how to fetch an API (`fetch-api`)
- how to do server side rendering with preact (`preact-ssr`)
- how to do server side rendering with react (`react-ssr`)

More examples will be added in the future.