### PR TITLE
feat(runtime): add Headers API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,6 @@ jobs:
       run: |
         cd packages/runtime
         pnpm build
+        pnpm build:runtime
     - name: Run Vitest
       run: pnpm test

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,8 +9,9 @@
     "dist"
   ],
   "scripts": {
-    "watch": "tsup src/index.ts src/runtime/* --format=esm --dts --no-splitting --watch",
-    "build": "tsup src/index.ts src/runtime/* --format=esm --dts --no-splitting"
+    "watch": "tsup src/index.ts --format=esm --dts --watch",
+    "build": "tsup src/index.ts --format=esm --dts",
+    "build:runtime": "for file in src/runtime/*; do tsup $file --format=esm --dts --out-dir dist/runtime; done"
   },
   "dependencies": {
     "isolated-vm": "^4.4.1"

--- a/packages/runtime/src/__tests__/fetch.test.ts
+++ b/packages/runtime/src/__tests__/fetch.test.ts
@@ -3,6 +3,7 @@ import { getIsolate } from '../isolate';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { HandlerRequest } from '..';
 import { createServer } from 'node:http';
+import { Headers } from '../runtime/fetch';
 
 const getDeployment = (): Deployment => ({
   functionId: 'functionId',
@@ -55,6 +56,112 @@ beforeAll(() => {
 
 afterAll(() => {
   server.close();
+});
+
+describe('Headers', () => {
+  describe('instanciate', () => {
+    it('should instanciate without init', () => {
+      expect(new Headers().toString()).toBeDefined();
+    });
+
+    it('should instanciate with init as object', () => {
+      expect(new Headers({ 'Content-Type': 'image/jpeg', 'X-My-Custom-Header': 'Zeke are cool' })).toBeDefined();
+    });
+
+    it('should instanciate with init as array', () => {
+      expect(
+        new Headers([
+          ['Set-Cookie', 'greeting=hello'],
+          ['Set-Cookie', 'name=world'],
+        ]),
+      ).toBeDefined();
+    });
+  });
+
+  it('should append', () => {
+    const headers = new Headers();
+    headers.append('a', 'b');
+    headers.append('c', 'd');
+    expect(headers.get('a')).toEqual('b');
+    expect(headers.get('c')).toEqual('d');
+  });
+
+  it('should delete', () => {
+    const headers = new Headers({
+      a: 'b',
+      c: 'd',
+    });
+    headers.delete('a');
+    expect(headers.get('a')).toBeUndefined();
+  });
+
+  it('should return entries', () => {
+    const headers = new Headers({
+      a: 'b',
+      c: 'd',
+    });
+    expect(Array.from(headers.entries())).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+  });
+
+  it('should get', () => {
+    const headers = new Headers({
+      a: 'b',
+      c: 'd',
+    });
+    expect(headers.get('a')).toEqual('b');
+    expect(headers.get('c')).toEqual('d');
+    expect(headers.get('e')).toBeUndefined();
+  });
+
+  it('should has', () => {
+    const headers = new Headers({
+      a: 'b',
+      c: 'd',
+    });
+    expect(headers.has('a')).toBeTruthy();
+    expect(headers.has('c')).toBeTruthy();
+    expect(headers.has('e')).toBeFalsy();
+  });
+
+  it('should return keys', () => {
+    const headers = new Headers({
+      a: 'b',
+      c: 'd',
+    });
+    expect(Array.from(headers.keys())).toEqual(['a', 'c']);
+  });
+
+  describe('set', () => {
+    it('should set without init', () => {
+      const headers = new Headers();
+      headers.set('a', 'b');
+      headers.set('c', 'd');
+      expect(headers.get('a')).toEqual('b');
+      expect(headers.get('c')).toEqual('d');
+    });
+
+    it('should set with init', () => {
+      const headers = new Headers({
+        a: 'b',
+        c: 'd',
+      });
+      headers.set('a', 'e');
+      headers.set('c', 'f');
+      expect(headers.get('a')).toEqual('e');
+      expect(headers.get('c')).toEqual('f');
+    });
+  });
+
+  it('should return values', () => {
+    const headers = new Headers({
+      a: 'b',
+      c: 'd',
+    });
+    expect(Array.from(headers.values())).toEqual(['b', 'd']);
+  });
 });
 
 describe('fetch', () => {

--- a/packages/runtime/src/runtime/Request.ts
+++ b/packages/runtime/src/runtime/Request.ts
@@ -1,20 +1,31 @@
+import { Headers } from './fetch';
 import { parseMultipart } from './parseMultipart';
 
 export interface RequestInit {
   method?: string;
-  headers?: Record<string, string | string[] | undefined>;
+  headers?: Headers | Record<string, string>;
   body?: string;
 }
 
 export class Request {
   method: string;
-  headers: Record<string, string | string[] | undefined>;
+  headers: Headers;
   body?: string;
   url: string;
 
   constructor(input: string, options?: RequestInit) {
     this.method = options?.method || 'GET';
-    this.headers = options?.headers || {};
+
+    if (options?.headers) {
+      if (options.headers instanceof Headers) {
+        this.headers = options.headers;
+      } else {
+        this.headers = new Headers(options.headers);
+      }
+    } else {
+      this.headers = new Headers();
+    }
+
     this.body = options?.body;
     this.url = input;
   }

--- a/packages/runtime/src/runtime/Response.ts
+++ b/packages/runtime/src/runtime/Response.ts
@@ -1,15 +1,16 @@
+import { Headers } from './fetch';
 import { parseMultipart } from './parseMultipart';
 
 export interface ResponseInit {
   status?: number;
   statusText?: string;
-  headers?: Record<string, string | string[] | undefined>;
+  headers?: Headers | Record<string, string>;
   url?: string;
 }
 
 export class Response {
   body: string;
-  headers: Record<string, string | string[] | undefined>;
+  headers: Headers;
   ok: boolean;
   status: number;
   statusText: string;
@@ -17,7 +18,16 @@ export class Response {
 
   constructor(body: string, options?: ResponseInit) {
     this.body = body;
-    this.headers = options?.headers || {};
+
+    if (options?.headers) {
+      if (options.headers instanceof Headers) {
+        this.headers = options.headers;
+      } else {
+        this.headers = new Headers(options.headers);
+      }
+    } else {
+      this.headers = new Headers();
+    }
 
     if (options?.status) {
       this.ok = options.status >= 200 && options.status < 300;

--- a/packages/runtime/src/runtime/fetch.ts
+++ b/packages/runtime/src/runtime/fetch.ts
@@ -1,6 +1,74 @@
 import { RequestInit } from './Request';
 import { Response } from './Response';
 
+export class Headers {
+  private headers: Map<string, string[]> = new Map();
+
+  constructor(init?: Record<string, string> | string[][]) {
+    if (init) {
+      if (Array.isArray(init)) {
+        init.forEach(([key, value]) => {
+          this.addValue(key, value);
+        });
+      } else {
+        Object.entries(init).forEach(([key, value]) => {
+          this.addValue(key, value);
+        });
+      }
+    }
+  }
+
+  private addValue(name: string, value: string) {
+    const values = this.headers.get(name);
+
+    if (values) {
+      values.push(value);
+    } else {
+      this.headers.set(name, [value]);
+    }
+  }
+
+  append(name: string, value: string) {
+    this.addValue(name, value);
+  }
+
+  delete(name: string) {
+    this.headers.delete(name);
+  }
+
+  *entries(): IterableIterator<[string, string]> {
+    for (const [key, values] of this.headers) {
+      for (const value of values) {
+        yield [key, value];
+      }
+    }
+  }
+
+  get(name: string): string | undefined {
+    return this.headers.get(name)?.[0];
+  }
+
+  has(name: string): boolean {
+    return this.headers.has(name);
+  }
+
+  keys(): IterableIterator<string> {
+    return this.headers.keys();
+  }
+
+  set(name: string, value: string) {
+    this.headers.set(name, [value]);
+  }
+
+  *values(): IterableIterator<string> {
+    for (const [, values] of this.headers) {
+      for (const value of values) {
+        yield value;
+      }
+    }
+  }
+}
+
 export async function fetch(resource: string, init: RequestInit) {
   // @ts-expect-error $0 is not defined
   const result = await $0.apply(undefined, [resource, init], {
@@ -11,4 +79,5 @@ export async function fetch(resource: string, init: RequestInit) {
   return new Response(result.body, result.options);
 }
 
+// @ts-expect-error global.fetch is not defined
 global.fetch = fetch;

--- a/packages/runtime/src/runtime/parseMultipart.ts
+++ b/packages/runtime/src/runtime/parseMultipart.ts
@@ -1,9 +1,11 @@
-export const parseMultipart = (headers: Record<string, string | string[] | undefined>, body?: string) => {
+import { Headers } from './fetch';
+
+export const parseMultipart = (headers: Headers, body?: string) => {
   if (!body) {
     return {};
   }
 
-  const contentTypeHeader = headers['content-type'];
+  const contentTypeHeader = headers.get('content-type');
   let boundary: string | undefined;
 
   const getBoundary = (header: string | undefined) => header?.split(';')?.[1]?.split('=')?.[1];

--- a/packages/types/generate.mjs
+++ b/packages/types/generate.mjs
@@ -4,7 +4,7 @@ import { $, cd, fs, glob } from 'zx';
 
 cd('../runtime');
 
-await $`pnpm build`;
+await $`pnpm build:runtime`;
 const declarationFiles = await glob('dist/runtime/*.d.ts');
 
 let finalDeclarationFile = `/**

--- a/packages/types/types.d.ts
+++ b/packages/types/types.d.ts
@@ -5,14 +5,28 @@
 
 /* eslint-disable */
 
+declare class Headers {
+    private headers;
+    constructor(init?: Record<string, string> | string[][]);
+    private addValue;
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    entries(): IterableIterator<[string, string]>;
+    get(name: string): string | undefined;
+    has(name: string): boolean;
+    keys(): IterableIterator<string>;
+    set(name: string, value: string): void;
+    values(): IterableIterator<string>;
+}
+
 interface RequestInit {
     method?: string;
-    headers?: Record<string, string | string[] | undefined>;
+    headers?: Headers | Record<string, string>;
     body?: string;
 }
 declare class Request {
     method: string;
-    headers: Record<string, string | string[] | undefined>;
+    headers: Headers;
     body?: string;
     url: string;
     constructor(input: string, options?: RequestInit);
@@ -22,15 +36,29 @@ declare class Request {
 }
 
 
+declare class Headers {
+    private headers;
+    constructor(init?: Record<string, string> | string[][]);
+    private addValue;
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    entries(): IterableIterator<[string, string]>;
+    get(name: string): string | undefined;
+    has(name: string): boolean;
+    keys(): IterableIterator<string>;
+    set(name: string, value: string): void;
+    values(): IterableIterator<string>;
+}
+
 interface ResponseInit {
     status?: number;
     statusText?: string;
-    headers?: Record<string, string | string[] | undefined>;
+    headers?: Headers | Record<string, string>;
     url?: string;
 }
 declare class Response {
     body: string;
-    headers: Record<string, string | string[] | undefined>;
+    headers: Headers;
     ok: boolean;
     status: number;
     statusText: string;
@@ -91,12 +119,55 @@ declare class TextDecoder {
 }
 
 
+interface RequestInit {
+    method?: string;
+    headers?: Headers | Record<string, string>;
+    body?: string;
+}
 
+declare class Response {
+    body: string;
+    headers: Headers;
+    ok: boolean;
+    status: number;
+    statusText: string;
+    url: string;
+    constructor(body: string, options?: ResponseInit);
+    text(): Promise<string>;
+    json<T>(): Promise<T>;
+    formData(): Promise<Record<string, string>>;
+}
 
-
+declare class Headers {
+    private headers;
+    constructor(init?: Record<string, string> | string[][]);
+    private addValue;
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    entries(): IterableIterator<[string, string]>;
+    get(name: string): string | undefined;
+    has(name: string): boolean;
+    keys(): IterableIterator<string>;
+    set(name: string, value: string): void;
+    values(): IterableIterator<string>;
+}
 declare function fetch(resource: string, init: RequestInit): Promise<Response>;
 
 
-declare const parseMultipart: (headers: Record<string, string | string[] | undefined>, body?: string | undefined) => Record<string, string>;
+declare class Headers {
+    private headers;
+    constructor(init?: Record<string, string> | string[][]);
+    private addValue;
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    entries(): IterableIterator<[string, string]>;
+    get(name: string): string | undefined;
+    has(name: string): boolean;
+    keys(): IterableIterator<string>;
+    set(name: string, value: string): void;
+    values(): IterableIterator<string>;
+}
+
+declare const parseMultipart: (headers: Headers, body?: string | undefined) => Record<string, string>;
 
 


### PR DESCRIPTION
Closes #30 

Add tests for this new `Headers` API, convert usage of `headers` in `Request` and `Response` and update the runtime building strategy.