### PR TITLE
feat(website): add profile page

### DIFF
--- a/packages/website/global.d.ts
+++ b/packages/website/global.d.ts
@@ -10,6 +10,7 @@ declare module 'next-auth' {
     };
     user: {
       id: string;
+      name: string;
       email: string;
     };
   }

--- a/packages/website/lib/Layout.tsx
+++ b/packages/website/lib/Layout.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { ComponentProps, ReactElement, ReactNode, Suspense, useCallback, useMemo } from 'react';
 import Button from 'lib/components/Button';
-import { ChevronDownIcon, CogIcon, LogoutIcon, PlusIcon } from '@heroicons/react/outline';
+import { ChevronDownIcon, CogIcon, LogoutIcon, PlusIcon, UserIcon } from '@heroicons/react/outline';
 import Menu from 'lib/components/Menu';
 import Divider from 'lib/components/Divider';
 import Text from 'lib/components/Text';
@@ -117,6 +117,9 @@ const Layout = ({ title, titleStatus, rightItem, headerOnly, children }: LayoutP
                       Settings
                     </Menu.Item>
                     <Divider />
+                    <Menu.Item icon={<UserIcon className="w-4 h-4" />} href="/profile">
+                      Profile
+                    </Menu.Item>
                     <Menu.Item icon={<LogoutIcon className="w-4 h-4" />} onClick={() => signOut()}>
                       Sign out
                     </Menu.Item>

--- a/packages/website/lib/hooks/useTokens.ts
+++ b/packages/website/lib/hooks/useTokens.ts
@@ -1,0 +1,7 @@
+import { trpc } from 'lib/trpc';
+
+const useTokens = () => {
+  return trpc.useQuery(['tokens.list']);
+};
+
+export default useTokens;

--- a/packages/website/lib/trpc/accountsRouter.ts
+++ b/packages/website/lib/trpc/accountsRouter.ts
@@ -1,0 +1,27 @@
+import prisma from 'lib/prisma';
+import { createRouter } from 'pages/api/trpc/[trpc]';
+import { z } from 'zod';
+
+export const accountsRouter = () =>
+  createRouter().mutation('update', {
+    input: z.object({
+      name: z.string(),
+      email: z.string(),
+    }),
+    resolve: async ({ ctx, input }) => {
+      return prisma.user.update({
+        where: {
+          id: ctx.session.user.id,
+        },
+        data: {
+          name: input.name,
+          email: input.email,
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      });
+    },
+  });

--- a/packages/website/lib/trpc/tokensRouter.ts
+++ b/packages/website/lib/trpc/tokensRouter.ts
@@ -5,6 +5,23 @@ import * as trpc from '@trpc/server';
 
 export const tokensRouter = () =>
   createRouter()
+    .query('list', {
+      resolve: async ({ ctx }) => {
+        return prisma.token.findMany({
+          where: {
+            userId: ctx.session.user.id,
+          },
+          select: {
+            id: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+        });
+      },
+    })
     .query('verification-code', {
       resolve: async ({ ctx }) => {
         const user = await prisma.user.findFirst({
@@ -91,5 +108,17 @@ export const tokensRouter = () =>
         }
 
         return { token: token.value };
+      },
+    })
+    .mutation('delete', {
+      input: z.object({
+        tokenId: z.string(),
+      }),
+      resolve: async ({ input }) => {
+        return prisma.token.delete({
+          where: {
+            id: input.tokenId,
+          },
+        });
       },
     });

--- a/packages/website/pages/api/trpc/[trpc].ts
+++ b/packages/website/pages/api/trpc/[trpc].ts
@@ -8,6 +8,7 @@ import { deploymentsRouter } from 'lib/trpc/deploymentsRouter';
 import prisma from 'lib/prisma';
 import { Session } from 'next-auth';
 import * as Sentry from '@sentry/nextjs';
+import { accountsRouter } from 'lib/trpc/accountsRouter';
 
 const createContext = async ({ req, res }: trpcNext.CreateNextContextOptions) => {
   const tokenValue = req.headers['x-lagon-token'] as string;
@@ -70,7 +71,8 @@ const router = createRouter()
   .merge('functions.', functionsRouter())
   .merge('organizations.', organizationsRouter())
   .merge('tokens.', tokensRouter())
-  .merge('deployments.', deploymentsRouter());
+  .merge('deployments.', deploymentsRouter())
+  .merge('accounts.', accountsRouter());
 
 export type AppRouter = typeof router;
 

--- a/packages/website/pages/api/trpc/[trpc].ts
+++ b/packages/website/pages/api/trpc/[trpc].ts
@@ -29,8 +29,9 @@ const createContext = async ({ req, res }: trpcNext.CreateNextContextOptions) =>
     });
 
     if (!token) {
-      res.status(401).end();
-      return;
+      throw new trpc.TRPCError({
+        code: 'UNAUTHORIZED',
+      });
     }
 
     return {
@@ -50,8 +51,9 @@ const createContext = async ({ req, res }: trpcNext.CreateNextContextOptions) =>
     const session = await getSession({ req });
 
     if (!session) {
-      res.status(401).end();
-      return;
+      throw new trpc.TRPCError({
+        code: 'UNAUTHORIZED',
+      });
     }
 
     return {

--- a/packages/website/pages/profile.tsx
+++ b/packages/website/pages/profile.tsx
@@ -5,6 +5,7 @@ import Divider from 'lib/components/Divider';
 import Form from 'lib/components/Form';
 import Input from 'lib/components/Input';
 import Text from 'lib/components/Text';
+import { requiredValidator } from 'lib/form/validators';
 import useTokens from 'lib/hooks/useTokens';
 import Layout from 'lib/Layout';
 import { trpc } from 'lib/trpc';
@@ -16,6 +17,7 @@ const Profile = () => {
   const { data: session } = useSession();
   const { data: tokens, refetch } = useTokens();
   const deleteToken = trpc.useMutation(['tokens.delete']);
+  const updateAccount = trpc.useMutation(['accounts.update']);
 
   const removeToken = useCallback(
     async (token: typeof tokens[number]) => {
@@ -32,6 +34,39 @@ const Profile = () => {
   return (
     <Layout title="Profile">
       <div className="flex flex-col gap-8">
+        <Card title="Information" description="Edit your account information like your name and email.">
+          <Form
+            initialValues={{
+              name: session?.user.name,
+              email: session?.user.email,
+            }}
+            onSubmit={async ({ name, email }) => {
+              await updateAccount.mutateAsync({
+                name,
+                email,
+              });
+
+              await refetch();
+            }}
+            onSubmitSuccess={() => {
+              toast.success('Information updated successfully.');
+            }}
+          >
+            <div className="flex justify-between items-start gap-12 mb-6">
+              <div className="flex flex-1 flex-col gap-1">
+                <Text size="lg">Name</Text>
+                <Input name="name" placeholder="John Doe" validator={requiredValidator} />
+              </div>
+              <div className="flex flex-1 flex-col gap-1">
+                <Text size="lg">Email</Text>
+                <Input name="email" type="email" placeholder="john@doe.com" validator={requiredValidator} />
+              </div>
+            </div>
+            <Button variant="primary" submit>
+              Update
+            </Button>
+          </Form>
+        </Card>
         <Card title="Tokens" description="Below are your personal tokens, used for the CLI.">
           <div>
             {tokens?.map(token => (

--- a/packages/website/pages/profile.tsx
+++ b/packages/website/pages/profile.tsx
@@ -1,0 +1,113 @@
+import Button from 'lib/components/Button';
+import Card from 'lib/components/Card';
+import Dialog from 'lib/components/Dialog';
+import Divider from 'lib/components/Divider';
+import Form from 'lib/components/Form';
+import Input from 'lib/components/Input';
+import Text from 'lib/components/Text';
+import useTokens from 'lib/hooks/useTokens';
+import Layout from 'lib/Layout';
+import { trpc } from 'lib/trpc';
+import { useSession } from 'next-auth/react';
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+
+const Profile = () => {
+  const { data: session } = useSession();
+  const { data: tokens, refetch } = useTokens();
+  const deleteToken = trpc.useMutation(['tokens.delete']);
+
+  const removeToken = useCallback(
+    async (token: typeof tokens[number]) => {
+      await deleteToken.mutateAsync({
+        tokenId: token.id,
+      });
+
+      await refetch();
+      toast.success('Token has been deleted.');
+    },
+    [deleteToken, refetch],
+  );
+
+  return (
+    <Layout title="Profile">
+      <div className="flex flex-col gap-8">
+        <Card title="Tokens" description="Below are your personal tokens, used for the CLI.">
+          <div>
+            {tokens?.map(token => (
+              <>
+                <Divider />
+                <div key={token.id} className="flex items-center justify-between px-4">
+                  <Text strong>********</Text>
+                  <Text size="sm">
+                    Created:&nbsp;
+                    {new Date(token.createdAt).toLocaleString('en-US', {
+                      minute: 'numeric',
+                      hour: 'numeric',
+                      day: 'numeric',
+                      month: 'long',
+                      year: 'numeric',
+                    })}
+                  </Text>
+                  <Dialog
+                    title="Delete token"
+                    description="Are you sure you want to delete this token? You will lose access to the CLI if it is still used."
+                    disclosure={
+                      <Button variant="danger" disabled={deleteToken.isLoading}>
+                        Delete
+                      </Button>
+                    }
+                  >
+                    <Dialog.Buttons>
+                      <Dialog.Cancel disabled={deleteToken.isLoading} />
+                      <Dialog.Action
+                        variant="danger"
+                        onClick={() => removeToken(token)}
+                        disabled={deleteToken.isLoading}
+                      >
+                        Delete Token
+                      </Dialog.Action>
+                    </Dialog.Buttons>
+                  </Dialog>
+                </div>
+              </>
+            ))}
+          </div>
+        </Card>
+        <Card title="Delete" description="Delete permanentently this account. This action is irreversible." danger>
+          <Dialog
+            title="Delete Account"
+            description={`Write your account email to confirm deletion: ${session?.user.email}`}
+            disclosure={<Button variant="danger">Delete</Button>}
+          >
+            <Form
+              onSubmit={() => {
+                // TODO
+                toast.error('Account deletion is not implemented yet.');
+              }}
+              onSubmitSuccess={async () => null}
+            >
+              {handleSubmit => (
+                <>
+                  <Input
+                    name="confirm"
+                    placeholder={session?.user.email}
+                    validator={value => (value !== session?.user.email ? 'Confirm with the your email' : undefined)}
+                  />
+                  <Dialog.Buttons>
+                    <Dialog.Cancel />
+                    <Dialog.Action variant="danger" onClick={handleSubmit}>
+                      Delete Account
+                    </Dialog.Action>
+                  </Dialog.Buttons>
+                </>
+              )}
+            </Form>
+          </Dialog>
+        </Card>
+      </div>
+    </Layout>
+  );
+};
+
+export default Profile;


### PR DESCRIPTION
Add profile page on the website, accessible from the menu:

![Screenshot 2022-06-27 at 19 47 36](https://user-images.githubusercontent.com/43268759/176003778-8882ef13-c716-4e40-9346-c60dcfa08009.png)

## Sections

Update name / email:

![Screenshot 2022-06-27 at 20 01 23](https://user-images.githubusercontent.com/43268759/176006231-98f8ffdf-7ac9-4286-a99a-a87ba9f3e0e3.png)

List and delete your tokens:

![Screenshot 2022-06-27 at 19 48 11](https://user-images.githubusercontent.com/43268759/176003881-42da6814-9f03-4f83-96f1-beeac3622ead.png)

Delete account:

![Screenshot 2022-06-27 at 19 48 28](https://user-images.githubusercontent.com/43268759/176003939-0b659ee4-eac2-4be6-beb0-23d1c9105ec1.png)