### PR TITLE
chore(ci): add typecheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 on:
+  push:
+    branches:
+      - main
   pull_request:
 jobs:
   lint:
@@ -44,3 +47,20 @@ jobs:
         pnpm build:runtime
     - name: Run Vitest
       run: pnpm test
+  typecheck:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: pnpm/action-setup@v2.2.2
+      with:
+        version: 7
+    - name: Use Node.js 18
+      uses: actions/setup-node@v2
+      with:
+        node-version: 18
+        cache: 'pnpm'
+    - name: Install dependencies
+      run: pnpm install
+    - name: Run TSC
+      # TODO: remove the | true when all type errors are resolved
+      run: pnpm tsc --noEmit | true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,5 @@ jobs:
     - name: Install dependencies
       run: pnpm install
     - name: Run TSC
-      # TODO: remove the | true when all type errors are resolved
-      run: pnpm tsc --noEmit | true
+      # TODO: remove the || true when all type errors are resolved
+      run: pnpm tsc --noEmit || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 16
+        cache: 'pnpm'
     - name: Install dependencies
       run: pnpm install
     - name: Build @lagon/runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,15 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [16, 18]
     steps:
     - uses: actions/checkout@v2
     - uses: pnpm/action-setup@v2.2.2
       with:
         version: 7
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 16
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 16
         cache: 'pnpm'
     - name: Install dependencies
       run: pnpm install
@@ -26,18 +23,15 @@ jobs:
       run: pnpm lint
   test:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [16, 18]
     steps:
     - uses: actions/checkout@v2
     - uses: pnpm/action-setup@v2.2.2
       with:
         version: 7
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 16
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 16
     - name: Install dependencies
       run: pnpm install
     - name: Build @lagon/runtime
@@ -54,10 +48,10 @@ jobs:
     - uses: pnpm/action-setup@v2.2.2
       with:
         version: 7
-    - name: Use Node.js 18
+    - name: Use Node.js 16
       uses: actions/setup-node@v2
       with:
-        node-version: 18
+        node-version: 16
         cache: 'pnpm'
     - name: Install dependencies
       run: pnpm install


### PR DESCRIPTION
- Add a typecheck job to run `tsc`
- Remove matrix to only use Node.js 16
- Run ci on push to main along with all pull requests